### PR TITLE
53: Always save Level before playing it

### DIFF
--- a/editor/Editor.cpp
+++ b/editor/Editor.cpp
@@ -1,6 +1,7 @@
 #include "Editor.hpp"
 #include "EditorGUI.hpp"
 #include "Enemy.hpp"
+#include "FileManager.hpp"
 #include "Game.hpp"
 #include "InputManager.hpp"
 #include "RenderCommand.hpp"
@@ -558,7 +559,7 @@ Editor::GetGridData() const
 }
 
 void
-Editor::CreateLevel(const glm::ivec2& size)
+Editor::CreateLevel(const std::string& name, const glm::ivec2& size)
 {
    if (m_levelLoaded)
    {
@@ -569,7 +570,7 @@ Editor::CreateLevel(const glm::ivec2& size)
    }
 
    m_currentLevel = std::make_shared< Level >();
-   m_currentLevel->Create(this, size);
+   m_currentLevel->Create(this, name, size);
    m_currentLevel->LoadShaders("Editor");
 
    // Populate editor objects
@@ -593,6 +594,7 @@ Editor::CreateLevel(const glm::ivec2& size)
    m_camera.SetLevelSize(m_currentLevel->GetSize());
 
    m_levelLoaded = true;
+   m_levelFileName = std::filesystem::path(LEVELS_DIR / std::string(name + ".dgl")).string();
    m_gui.LevelLoaded(m_currentLevel);
 }
 
@@ -660,7 +662,7 @@ void
 Editor::SaveLevel(const std::string& levelPath)
 {
    m_levelFileName = levelPath;
-   m_currentLevel->Save(levelPath);
+   m_currentLevel->Save(m_levelFileName);
 }
 
 void
@@ -732,6 +734,9 @@ Editor::IsObjectAnimated() const
 void
 Editor::PlayLevel()
 {
+   // TODO: For future we'd want to check if anything got changed,
+   //       so we don't always save (this can get costly later!)
+   m_currentLevel->Save(m_levelFileName);
    m_playGame = true;
 }
 

--- a/editor/Editor.hpp
+++ b/editor/Editor.hpp
@@ -56,7 +56,7 @@ class Editor : public Application
    Render();
 
    void
-   CreateLevel(const glm::ivec2& size);
+   CreateLevel(const std::string& name, const glm::ivec2& size);
 
    void
    LoadLevel(const std::string& levelPath);

--- a/editor/GUI/EditorGUI.cpp
+++ b/editor/GUI/EditorGUI.cpp
@@ -142,6 +142,32 @@ EditorGUI::IsBlockingEvents()
 }
 
 void
+EditorGUI::RenderCreateNewLevelWindow()
+{
+   const auto halfSize = m_windowSize / 2.0f;
+   static glm::ivec2 size = {1024, 1024};
+   static std::string name = "DummyLevelName";
+
+   ImGui::SetNextWindowPos({halfSize.x, halfSize.y});
+   ImGui::SetNextWindowSize({300, 100});
+   ImGui::Begin("Create New");
+   ImGui::InputInt2("Size", &size.x);
+   ImGui::InputText("Name", name.data(), name.length());
+   if (ImGui::Button("Create", {140, 25}))
+   {
+      m_parent.CreateLevel(name, size);
+      m_createPushed = false;
+   }
+   ImGui::SameLine();
+   if (ImGui::Button("Cancel", {140, 25}))
+   {
+      m_createPushed = false;
+   }
+
+   ImGui::End();
+}
+
+void
 EditorGUI::RenderMainPanel()
 {
    ImGui::SetNextWindowPos({0, 0});
@@ -177,9 +203,10 @@ EditorGUI::RenderMainPanel()
       }
    }
    ImGui::SameLine();
-   if (ImGui::Button("Create"))
+   if (ImGui::Button("Create") or m_createPushed)
    {
-      m_parent.CreateLevel({3072, 3072});
+      m_createPushed = true;
+      RenderCreateNewLevelWindow();
    }
    ImGui::End();
 }

--- a/editor/GUI/EditorGUI.cpp
+++ b/editor/GUI/EditorGUI.cpp
@@ -414,7 +414,7 @@ EditorGUI::RenderGameObjectMenu() // NOLINT
          }
 
          ImGui::SameLine();
-         if (ImGui::SliderFloat("", &timer, 0.0f, animationDuration, "%.3f ms"))
+         if (ImGui::SliderFloat("##", &timer, 0.0f, animationDuration, "%.3f ms"))
          {
             m_currentlySelectedGameObject->GetSprite().SetTranslateValue(
                animatablePtr->SetAnimation(Timer::milliseconds(static_cast< uint64_t >(timer))));

--- a/editor/GUI/EditorGUI.hpp
+++ b/editor/GUI/EditorGUI.hpp
@@ -64,6 +64,9 @@ class EditorGUI
    void
    RenderGameObjectMenu();
 
+   void
+   RenderCreateNewLevelWindow();
+
    Editor& m_parent;
 
    // EditorObjectWindow m_editorObjectWindow;
@@ -77,6 +80,8 @@ class EditorGUI
    float m_levelWindowHeight = 0.0f;
    float m_debugWindowHeight = 0.0f;
    float m_debugWindowWidth = 0.0f;
+
+   bool m_createPushed = false;
 };
 
 } // namespace dgame

--- a/engine/Game/Level.cpp
+++ b/engine/Game/Level.cpp
@@ -16,8 +16,9 @@
 namespace dgame {
 
 void
-Level::Create(Application* context, const glm::ivec2& size)
+Level::Create(Application* context, const std::string& name, const glm::ivec2& size)
 {
+   m_name = name;
    m_levelSize = size;
    const auto halfSize = size / 2;
    m_background.SetSprite(glm::vec2(halfSize), m_levelSize);

--- a/engine/Game/Level.hpp
+++ b/engine/Game/Level.hpp
@@ -46,7 +46,7 @@ class Level
                    Object::ID objectID);
 
    void
-   Create(Application* context, const glm::ivec2& size);
+   Create(Application* context, const std::string& name, const glm::ivec2& size);
 
    // pathToLevel - global path to level file (.dgl)
    void
@@ -203,6 +203,7 @@ class Level
 
    bool m_locked = false;
 
+   std::string m_name = "DummyName";
    glm::ivec2 m_levelSize = {0, 0};
    uint32_t m_tileWidth = 128;
    std::vector< std::shared_ptr< GameObject > > m_objects;


### PR DESCRIPTION
Fixes #53

**Changes:**
- always save Level before playing it (this probably needs to be changed later, to be conditionally saved only when there're changes)
- Add popup window for Level creation