### PR TITLE
60: Don't run CompileResultAction on master branch

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
         cmake --build . --config $BUILD_TYPE  2> >(tee "output.txt")
 
     - name: Post PR comment for warnings/errors
-      if: ${{ always() }}
+      if: github.ref != 'refs/heads/master'
       uses: JacobDomagala/CompileResultAction@master
       with:
         comment_title: UBUNTU COMPILE RESULT

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         cat output.txt
 
     - name: Post PR comment for warnings/errors
-      if: ${{ always() }}
+      if: github.ref != 'refs/heads/master'
       uses: JacobDomagala/CompileResultAction@master
       with:
         compile_result_file: ${{runner.workspace}}/build/output.txt


### PR DESCRIPTION
Fixes #60